### PR TITLE
Fixed issue with operation in error not being processed after 24 hours

### DIFF
--- a/src/Entity/OperationRepository.php
+++ b/src/Entity/OperationRepository.php
@@ -65,7 +65,7 @@ class OperationRepository extends EntityRepository implements ManagerInterface
         $criteria = new Criteria();
         $exprBuilder = new ExpressionBuilder();
         $criteria->where($exprBuilder->eq('status', $status->getValue()));
-        $criteria->andWhere($exprBuilder->gte('updatedAt', $date));
+        $criteria->andWhere($exprBuilder->lte('updatedAt', $date));
         return $this->matching($criteria)->toArray();
     }
 


### PR DESCRIPTION
Hi, 

Once an operation is created it must be terminated, either it should be canceled or it should end with success. 

Right now once an operation is in error (Ex : because the bank informations of a vendor isn't yet validated therefore withdraw fails)it will be re-executed during 24 hours, but past that time it won't be. The technical specifications were clear, an operation in error needs to be re-executed once every 24 hours. 

I fixed that, :smile: 

For informations, the cashout:process cron should run more then once per cycle, it should run at least once a day in order to process all the operations. The documentation is recommending to run it once per cycle and I don't think it is enough. 
