### PR TITLE
Customize the error level for which emails should be sent

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -98,7 +98,7 @@ $messageTemplate->setTo($parameters['mail.to']);
 $messageTemplate->setFrom($parameters['mail.from']);
 $messageTemplate->setCharset('utf-8');
 $logger->pushHandler(
-    new SwiftMailerHandler($mailer, $messageTemplate, Logger::CRITICAL)
+    new SwiftMailerHandler($mailer, $messageTemplate, $parameters['email.logger.alert.level'])
 );
 
 $logger->pushProcessor(new PsrLogMessageProcessor());

--- a/config/parameters.yml.dist
+++ b/config/parameters.yml.dist
@@ -60,3 +60,14 @@ parameters:
 
   account.operator.email : ~
   account.operator.hipayId : ~
+
+  # The minimum logging level at which this handler will be triggered
+  # DEBUG = 100;
+  # INFO = 200;
+  # NOTICE = 250;
+  # WARNING = 300;
+  # ERROR = 400;
+  # CRITICAL = 500;
+  # ALERT = 550;
+  # EMERGENCY = 600;
+  email.logger.alert.level: 500


### PR DESCRIPTION
They would like to be able to receive notifications by email for warning notification.
At this time, emails are sent for critical errors only.
A parameters should be added in parameters.yml and this line should parameterized in bootstrap.php:

_$logger->pushHandler(
    new SwiftMailerHandler($mailer, $messageTemplate, *Logger::CRITICAL*)
);_
